### PR TITLE
a tiny change

### DIFF
--- a/handlers/start.py
+++ b/handlers/start.py
@@ -7,7 +7,7 @@ from forms.register import Register
 from utils.custom_filters import IsPrivate
 
 
-@dp.message_handler(IsPrivate, CommandStart())
+@dp.message_handler(CommandStart(), IsPrivate)
 async def start(msg):
     user = User.query.filter(User.id == msg.from_user.id).first()
     if user is not None:


### PR DESCRIPTION
its better this way, to check command first and then check the user or chat authority or another custom filter.
its may become a problem in large scale when more handlers and filters added. this way its checking filters on every handler and it can slow the bot down.